### PR TITLE
Make the main branch of repository configureable

### DIFF
--- a/Braumeister/actions/candidate.py
+++ b/Braumeister/actions/candidate.py
@@ -5,13 +5,13 @@ import sys
 
 from colorama import Fore
 
+from ..settings import Settings
 from ..git import Git, GitException
 from ..jira import Jira
 from ..state import State
 
 
 class Candidate:
-
     def __init__(self, fix_version, resume, update_jira):
         self.fix_version = fix_version
         self.resume = resume
@@ -25,32 +25,41 @@ class Candidate:
         if self.resume:
             data = State.read_file()
             branches = State.get_branches_from_data(data)
-            candidate_branch_name = data['newBranchName']
-            resume_code = data['resumeCode']
+            candidate_branch_name = data["newBranchName"]
+            resume_code = data["resumeCode"]
         else:
             branches = Jira.get_feature_branches(fix_version=self.fix_version)
 
             if not branches:
                 print("")
-                print(Fore.RED + "[-] " + Fore.RESET +
-                      "Found no issues for release candidate " + Fore.GREEN + "'" + self.fix_version + "'" + Fore.RESET + " in Jira.")
+                print(
+                    Fore.RED
+                    + "[-] "
+                    + Fore.RESET
+                    + "Found no issues for release candidate "
+                    + Fore.GREEN
+                    + "'"
+                    + self.fix_version
+                    + "'"
+                    + Fore.RESET
+                    + " in Jira."
+                )
                 print("    Please create a release in Jira first")
                 print(
-                    "      (and use the 'fixVersion' field to assign the release to a ticket) ")
+                    "      (and use the 'fixVersion' field to assign the release to a ticket) "
+                )
                 print("")
                 sys.exit(1)
 
-            candidate_branch_name = Git.create_candidate_branch(
-                self.fix_version)
+            candidate_branch_name = Git.create_candidate_branch(self.fix_version)
             resume_code = 0
 
         try:
             Git.merge_branches(branches, candidate_branch_name, resume_code)
         except GitException as e:
-            self.handle_error(branches,
-                              candidate_branch_name,
-                              e.abort_branch,
-                              e.resume_code)
+            self.handle_error(
+                branches, candidate_branch_name, e.abort_branch, e.resume_code
+            )
 
         State.delete_file()
 
@@ -66,7 +75,8 @@ class Candidate:
 
     def handle_error(self, branches, candidate_branch_name, abort_branch, resume_code):
         data = State.get_data_from_branches(
-            branches, candidate_branch_name, abort_branch, resume_code)
+            branches, candidate_branch_name, abort_branch, resume_code
+        )
         State.write_file(data)
 
         current_branch = Git.get_current_branch()
@@ -75,10 +85,16 @@ class Candidate:
         sys.exit(1)
 
     def print_after_error(self, current_branch):
+        main_branch_name = Settings.get("git", "main_branch_name", "master")
+
         if "release" in current_branch:
-            print("\nA merge error occurred while merging feature into " + current_branch)
+            print(
+                f"\nA merge error occurred while merging feature into {current_branch}"
+            )
         else:
-            print("\nA merge error occurred while merging master into " + current_branch)
+            print(
+                f"\nA merge error occurred while merging {main_branch_name} into {current_branch}"
+            )
 
         print("\nPlease do the following steps:")
         print("\t* Resolve the conflicts")

--- a/Braumeister/actions/finalize.py
+++ b/Braumeister/actions/finalize.py
@@ -5,11 +5,11 @@ import sys
 
 from colorama import Fore
 
+from ..settings import Settings
 from ..git import Git, GitException
 
 
 class Finalize:
-
     def __init__(self, fix_version, resume, update_jira):
         self.fix_version = fix_version
         self.resume = resume
@@ -19,16 +19,17 @@ class Finalize:
         Git.check_working_directory()
         Git.check_git_state()
 
+        main_branch_name = Settings.get("git", "main_branch_name", "master")
         branches = {}
 
         try:
             sourceBranch = Git.find_release_branch_name(self.fix_version)
             branches = {sourceBranch}
-            Git.merge_branches(branches, "master", 0)
+            Git.merge_branches(branches, main_branch_name, 0)
         except GitException as e:
             self.handle_error()
 
-        Git.push_branch("master")
+        Git.push_branch(main_branch_name)
 
         print("")
         print(Fore.GREEN + "[🍻 ] " + Fore.RESET + "All done. Grab a 🍺")
@@ -41,7 +42,11 @@ class Finalize:
         sys.exit(1)
 
     def print_after_error(self, current_branch):
-        print("\nA merge error occurred while merging " + current_branch + " into master")
+        main_branch_name = Settings.get("git", "main_branch_name", "master")
+
+        print(
+            f"\nA merge error occurred while merging {current_branch} into {main_branch_name}"
+        )
         print("\nPlease do the following steps:")
         print("\t* Resolve the conflicts")
         print("\t* Commit the changes")

--- a/Braumeister/braumeister.py
+++ b/Braumeister/braumeister.py
@@ -4,9 +4,9 @@ from .core import Core
 
 """braumeister.braumeister: provides entry point main()."""
 
-__version__ = "0.3.4"
-
-
 def main():
     b = Core()
     b.bootstap()
+
+if __name__ == '__main__':
+    main()

--- a/Braumeister/core.py
+++ b/Braumeister/core.py
@@ -1,13 +1,13 @@
 import argparse
 import sys
 
-import pkg_resources
 from colorama import init, Fore
 
 from .builder import Builder
 from .settings import Settings
 from .setup import Setup
 
+__version__ = "0.4.1"
 
 class Core:
 
@@ -15,11 +15,11 @@ class Core:
         init()
 
     def bootstap(self):
-        version = pkg_resources.require("braumeister")[0].version
+        #version = pkg_resources.require("braumeister")[0].version
 
         parser = argparse.ArgumentParser(
             description='Create (or finish up) a release (candidate) branch based on the "fixVersion" '
-                        'field in JIRA and your `master` branch. (v' + version + ")")
+                        'field in JIRA and your `main` branch. (v' + __version__ + ")")
 
         parser.add_argument(
             'action',
@@ -80,5 +80,6 @@ class Core:
             print(Fore.RED + "[-] " + Fore.RESET + "Error: " + error.args[0])
         except AttributeError as error:
             print(Fore.RED + "[-] " + Fore.RESET + "Error: operation '" + args.action + "' not supported")
+            print(f"Error: {error}")
         except Exception as error:
             print(Fore.RED + "[-] " + Fore.RESET + "Error: " + str(error))

--- a/Braumeister/jira.py
+++ b/Braumeister/jira.py
@@ -25,7 +25,8 @@ class Jira:
 
         if not custom_field_name:
             raise ValueError(
-                "Missing 'branch_custom_field_id' in 'jira' section. Please run 'braumeister init'")
+                "Missing 'branch_custom_field_id' in 'jira' section. Please run 'braumeister init'"
+            )
 
         for issue in json_object["issues"]:
             obj = Jira.get_specific_issue(issue["self"])
@@ -42,7 +43,11 @@ class Jira:
 
             if not key:
                 print(
-                    Fore.YELLOW + "[~] " + Fore.RESET + "Ticket with empty branch field found: %s - Ignoring." % issue)
+                    Fore.YELLOW
+                    + "[~] "
+                    + Fore.RESET
+                    + "Ticket with empty branch field found: %s - Ignoring." % issue
+                )
                 continue
 
             if key in branches:
@@ -58,14 +63,23 @@ class Jira:
     @staticmethod
     def get_relevant_issues(fix_version):
         print(
-            Fore.GREEN + "[*] " + Fore.RESET + "Requesting all issues with fixVersion: " + Fore.GREEN + fix_version + Fore.RESET)
+            Fore.GREEN
+            + "[*] "
+            + Fore.RESET
+            + "Requesting all issues with fixVersion: "
+            + Fore.GREEN
+            + fix_version
+            + Fore.RESET
+        )
 
         jira_url = Settings.get("jira", "url", None)
 
         if not jira_url:
-            raise ValueError("Missing 'url' in 'jira' section. Please run 'braumeister init'")
+            raise ValueError(
+                "Missing 'url' in 'jira' section. Please run 'braumeister init'"
+            )
 
-        query = "fixVersion=\"" + fix_version + "\" ORDER BY updated DESC"
+        query = 'fixVersion="' + fix_version + '" ORDER BY updated DESC'
         data = {"jql": query}
         url = "%s/rest/api/2/search" % jira_url
 
@@ -74,15 +88,26 @@ class Jira:
     @staticmethod
     def update_jira_issues(issues):
         print("------------------------------------")
-        print(Fore.GREEN + "[+]" + Fore.RESET + " Update status to Staging needed on all related jira issues!")
+        print(
+            Fore.GREEN
+            + "[+]"
+            + Fore.RESET
+            + " Update status to Staging needed on all related jira issues!"
+        )
 
         jira_url = Settings.get("jira", "url", None)
         if not jira_url:
-            raise ValueError("Missing 'url' in 'jira' section. Please run 'braumeister init'")
+            raise ValueError(
+                "Missing 'url' in 'jira' section. Please run 'braumeister init'"
+            )
 
-        jira_destination_transition = Settings.get("jira", "destination_transition", None)
+        jira_destination_transition = Settings.get(
+            "jira", "destination_transition", None
+        )
         if not jira_destination_transition:
-            raise ValueError("Missing 'destination_transition' in 'jira' section. Please run 'braumeister init'")
+            raise ValueError(
+                "Missing 'destination_transition' in 'jira' section. Please run 'braumeister init'"
+            )
 
         for issue in issues:
             url = "%s/rest/api/2/issue/%s/transitions" % (jira_url, issue)
@@ -95,14 +120,10 @@ class Jira:
 
     @staticmethod
     def update_jira_issue(issue, transition, url):
-        data = {
-            "transition": {
-                "id": transition["id"]
-            }
-        }
+        data = {"transition": {"id": transition["id"]}}
         print("Updating jira status on " + issue + " to " + transition["name"])
 
-        if (not Settings.is_dry_run()):
+        if not Settings.is_dry_run():
             Jira.call_jira_post(url, json.dumps(data))
 
     @staticmethod
@@ -118,14 +139,20 @@ class Jira:
 
         if not jira_user:
             raise ValueError(
-                "Missing 'username' in 'jira' section. Please run 'braumeister init'")
+                "Missing 'username' in 'jira' section. Please run 'braumeister init'"
+            )
 
         if not jira_password:
             raise ValueError(
-                "Missing 'password' in 'jira' section. Please run 'braumeister init'")
+                "Missing 'password' in 'jira' section. Please run 'braumeister init'"
+            )
 
-        response = requests.post(url, data=data, auth=(jira_user, jira_password),
-                                 headers={'content-type': 'application/json'})
+        response = requests.post(
+            url,
+            data=data,
+            auth=(jira_user, jira_password),
+            headers={"content-type": "application/json"},
+        )
 
         try:
             return json.loads(response.text)
@@ -138,12 +165,20 @@ class Jira:
         jira_password = Settings.get("jira", "password", None)
 
         if not jira_user:
-            raise ValueError("Missing 'username' in 'jira' section. Please run 'braumeister init'")
+            raise ValueError(
+                "Missing 'username' in 'jira' section. Please run 'braumeister init'"
+            )
 
         if not jira_password:
-            raise ValueError("Missing 'password' in 'jira' section. Please run 'braumeister init'")
+            raise ValueError(
+                "Missing 'password' in 'jira' section. Please run 'braumeister init'"
+            )
 
-        response = requests.get(url, auth=(jira_user, jira_password), headers={'content-type': 'application/json'})
+        response = requests.get(
+            url,
+            auth=(jira_user, jira_password),
+            headers={"content-type": "application/json"},
+        )
 
         try:
             return json.loads(response.text)

--- a/Braumeister/setup.py
+++ b/Braumeister/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from email.policy import default
 import os
 import getpass
 from colorama import Fore
@@ -31,6 +32,7 @@ class Setup:
         self.jira_pass = ""
         self.jira_destination_transition = ""
         self.jira_branch_field_id = ""
+        self.git_main_branch_name = "master"
 
     def print_success(self, message):
         print("%s[*]%s %s" % (Fore.GREEN, Fore.RESET, message))
@@ -58,12 +60,27 @@ class Setup:
 
         return answer
 
-    def ask_optional(self, question):
-        return self.print_question("%s (optional)" % question)
+    def ask_optional(self, question, default=None):
+        answer = self.print_question("%s (optional)" % question)
+        if answer == "" and default != None:
+            return default
+        return answer
 
     def url_validator(self, url):
         """ checks if the given url starts with 'http' """
         return url.startswith("http")
+
+    def ask_git(self):
+        """"""
+        print()
+        self.print_success("Git Configuration")
+        self.print_success("----------------------")
+        print()
+
+        self.git_main_branch_name = self.ask_optional(
+            "Main branch name [master]",
+            default=self.git_main_branch_name
+        )
 
     def ask_jira(self):
         """ Asking questions about the jira configuration """
@@ -110,10 +127,12 @@ class Setup:
         print("\t Please answer the following questions:")
         print()
 
+        self.ask_git()
         self.ask_jira()
 
         print()
 
+        Settings.save("git", "main_branch_name", self.git_main_branch_name)
         Settings.save("jira", "url", self.jira_url)
         Settings.save("jira", "username", self.jira_user)
         Settings.save("jira", "password", self.jira_pass)

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Switched to a new branch 'release/Barking_Dog_GA'
 ```
 
 #### Finalize a release
-When you execute the `braumeister` with the `finalize` action it will merge the given branch back to `origin/master`. 
+When you execute the `braumeister` with the `finalize` action it will merge the given branch back to define main branch (e.g. `origin/main`).
 
 THIS CHANGES YOUR REMOTE REPOSITORY, HANDLE WITH CARE!
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ The `braumeister` will create a `.braumeister` configuration file in the current
 [general]
 verbose = false
 
+[git]
+main_branch_name = main
+
 [jira]
 url = https://jira.dev
 username = my-user
@@ -45,6 +48,7 @@ branch_custom_field_id = customfield_5711
 |Section|key|default value|description|
 |-------|---|-----|---|
 |general|verbose|false|Verbose output|
+|git|main_branch_name|master|Define the main branch name for your git project|
 |jira|url|None|JIRA Base URL|
 |jira|username|None|A JIRA User|
 |jira|password|None|The password for the user|
@@ -91,7 +95,7 @@ For each of theses branches, the following commands will be executed:
 ```sh
 $ git checkout $branch
 $ git pull
-$ git merge origin/master
+$ git merge origin/main
 $ git push origin $branch
 $ git checkout $release_branch
 $ git merge origin/$branch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests=2.20.0
-colorama=0.4.0
+requests==2.20.0
+colorama==0.4.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+black
+pylint

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 version = re.search(
     '^__version__\s*=\s*"(.*)"',
-    open('braumeister/braumeister.py').read(),
+    open('braumeister/core.py').read(),
     re.M
 ).group(1)
 


### PR DESCRIPTION
Fixes #9 

This PR creates a new configuration option (`git.main_branch_name`) that defines the overall source branch of a repository (e.g. `main` or `master`).
For backwards compatibility, the default main branch name is `master`.