### PR TITLE
#17 Pre-Check if all branches extists

### DIFF
--- a/Braumeister/actions/candidate.py
+++ b/Braumeister/actions/candidate.py
@@ -51,6 +51,8 @@ class Candidate:
                 print("")
                 sys.exit(1)
 
+            Git.try_before_merge(branches)
+
             candidate_branch_name = Git.create_candidate_branch(self.fix_version)
             resume_code = 0
 

--- a/Braumeister/core.py
+++ b/Braumeister/core.py
@@ -7,7 +7,7 @@ from .builder import Builder
 from .settings import Settings
 from .setup import Setup
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 class Core:
 

--- a/Braumeister/setup.py
+++ b/Braumeister/setup.py
@@ -33,6 +33,7 @@ class Setup:
         self.jira_destination_transition = ""
         self.jira_branch_field_id = ""
         self.git_main_branch_name = "master"
+        self.git_try_before_merge = False
 
     def print_success(self, message):
         print("%s[*]%s %s" % (Fore.GREEN, Fore.RESET, message))
@@ -81,6 +82,16 @@ class Setup:
             "Main branch name [master]",
             default=self.git_main_branch_name
         )
+
+        git_try_before_merge = self.ask_optional(
+            "Should we check for the existence of the branches, before creating a release canidate? [no]",
+            default=self.git_try_before_merge
+        )
+
+        if git_try_before_merge in ["y", "yes", "j", "ja"]:
+            self.git_try_before_merge = True
+        else:
+            self.git_try_before_merge = False
 
     def ask_jira(self):
         """ Asking questions about the jira configuration """
@@ -133,6 +144,7 @@ class Setup:
         print()
 
         Settings.save("git", "main_branch_name", self.git_main_branch_name)
+        Settings.save("git", "try_before_merge", self.git_try_before_merge)
         Settings.save("jira", "url", self.jira_url)
         Settings.save("jira", "username", self.jira_user)
         Settings.save("jira", "password", self.jira_pass)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ verbose = false
 
 [git]
 main_branch_name = main
+try_before_merge = false
 
 [jira]
 url = https://your-domain.atlassian.net
@@ -49,6 +50,7 @@ branch_custom_field_id = customfield_5711
 |-------|---|-----|---|
 |general|verbose|false|Verbose output|
 |git|main_branch_name|master|Define the main branch name for your git project|
+|git|try_before_merge|false|Flag to check for the existence of the branches before creating a RC|
 |jira|url|None|JIRA Base URL|
 |jira|username|None|A JIRA User|
 |jira|password|None|The password for the user|


### PR DESCRIPTION
#17 

If configured, this checks for the existence of all given branches before creating a RC. If 1 or more branches can't be found in the current repository, all non-existing branches will be listed.

The output looks like this:

```
[?] Trying branch affe
[+] Calling: git ls-remote --heads origin affe
c94d8e697df9f319e896fd7fbe543d93bcd3488c	refs/heads/affe

[?] Trying branch i-dont-exists
[+] Calling: git ls-remote --heads origin i-dont-exists

[?] Trying branch typo-in-branch-name
[+] Calling: git ls-remote --heads origin typo-in-branch-name

[-] Uh-oh! The following branches does not exists:
[-]	'i-dont-exists'
[-]	'typo-in-branch-name'
[-] Error: Non existing branches found.
```