### PR TITLE
#27 Trim branch names before using it for any git commands

### DIFF
--- a/Braumeister/git.py
+++ b/Braumeister/git.py
@@ -203,7 +203,7 @@ class Git:
         current_branch = ""
         code = resume_code
         for key in branches:
-            current_branch = key
+            current_branch = key.strip()
             try:
                 if Settings.get("general", "verbose", False):
                     print("------------------------------------")

--- a/Braumeister/jira.py
+++ b/Braumeister/jira.py
@@ -39,7 +39,7 @@ class Jira:
                     "Missing %s in jira custom fields. Are you sure the name is %s? I've found these: \n%s" % (
                         custom_field_name, custom_field_name, ", ".join(obj["fields"])))
 
-            key = obj["fields"][custom_field_name]
+            key = obj["fields"][custom_field_name].strip()
 
             if not key:
                 print(


### PR DESCRIPTION
Fixes #27 

This PR strips whitespaces chars (left & right) before using the branch name from Jira.